### PR TITLE
Capitalize t in tutorial in final cta section

### DIFF
--- a/web/src/components/FinalCTASection/FinalCTASection.tsx
+++ b/web/src/components/FinalCTASection/FinalCTASection.tsx
@@ -63,7 +63,7 @@ const FinalCtaSection = () => {
             href="/docs/tutorial"
             className="button bg-rw-500 hover:bg-rw-700 px-9 text-white"
           >
-            Start the tutorial
+            Start the Tutorial
           </a>
         </section>
       </section>


### PR DESCRIPTION
Wasn't sure if this was intentionally lowercased or not. If not, this PR makes it consistent with the other CTAs.