### PR TITLE
Capitalize "t" in tutorial for consistency

### DIFF
--- a/web/src/components/TestimonialSection/TestimonialSection.tsx
+++ b/web/src/components/TestimonialSection/TestimonialSection.tsx
@@ -47,7 +47,7 @@ const TestimonialSection = () => {
           Redwood adventure?
         </h3>
         <a href="https://redwoodjs.com/docs/tutorial" className="button">
-          Start the tutorial
+          Start the Tutorial
         </a>
       </section>
     </div>


### PR DESCRIPTION
Capitalizes the "t" in the testimonial section.

<img width="1522" alt="image" src="https://user-images.githubusercontent.com/32992335/161508865-2d08a88c-e6cb-4180-b5e2-dbbf0d40be3d.png">
