### PR TITLE
Make hero image load faster

### DIFF
--- a/web/src/components/HeroSection/HeroSection.tsx
+++ b/web/src/components/HeroSection/HeroSection.tsx
@@ -2,9 +2,14 @@ import { ChevronDownIcon } from '@heroicons/react/solid'
 const HeroSection = () => {
   return (
     <section className="relative flex min-h-[calc(100vh-64px)] bg-[url(/public/images/forest.svg)] bg-cover bg-bottom bg-no-repeat">
+      <img
+        src="/public/images/forest.svg"
+        alt="Speed up hero image discovery by the browser"
+        className="hidden w-0 h-0"
+      />
       <div className="flex flex-1 bg-gradient-to-t from-black">
-        <div className="mb-10 flex flex-1 items-center p-4 md:p-12 lg:p-32">
-          <div className="flex flex-1 flex-col space-y-12 rounded-2xl p-8 text-left text-white lg:items-center lg:justify-center lg:px-12 lg:py-24 lg:text-center">
+        <div className="flex items-center flex-1 p-4 mb-10 md:p-12 lg:p-32">
+          <div className="flex flex-col flex-1 p-8 space-y-12 text-left text-white rounded-2xl lg:items-center lg:justify-center lg:px-12 lg:py-24 lg:text-center">
             <h1 className="flex flex-col font-serif text-4xl font-bold md:text-6xl  2xl:text-7xl 2xl:leading-[100px]">
               <span>Focus on building your startup,</span>
               <span>not fighting your framework.</span>
@@ -21,8 +26,8 @@ const HeroSection = () => {
             </a>
           </div>
         </div>
-        <div className="absolute bottom-0 flex h-10 w-full items-center justify-center text-white">
-          <ChevronDownIcon className="h-8 w-8" />
+        <div className="absolute bottom-0 flex items-center justify-center w-full h-10 text-white">
+          <ChevronDownIcon className="w-8 h-8" />
         </div>
       </div>
     </section>


### PR DESCRIPTION
This change, with a little bit of luck, will cause hero image to be pushed up in the priority of loading for most browers.

According to [this test](https://webpagetest.org/result/220407_AiDc47_P6/1/details/#waterfall_view_step1) it is at position 46, which is not ideal considering its importance for metrics like Largest Contentful Paint and overall experience (gray background during loading)
