### PR TITLE
fix(redirects): Add redirect from /good-first-issue

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -83,6 +83,12 @@ functions = "api/dist/functions"
   from = "/roadmap"
   to = "https://community.redwoodjs.com/t/post-v1-roadmap-feedback-wanted/3013"
 
+
+[[redirects]]
+  from = "/good-first-issue"
+  to = "https://github.com/redwoodjs/redwood/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+sort%3Aupdated-desc"
+
+
 [[redirects]]
   from = "/*"
   to = "/200.html"


### PR DESCRIPTION
As title

We're missing a redirect that we use on the default landing page. See: https://github.com/redwoodjs/redwood/issues/5113