### PR TITLE
Self-host atom-one-light theme for highlight.js

### DIFF
--- a/web/src/atom-one-light.css
+++ b/web/src/atom-one-light.css
@@ -1,0 +1,79 @@
+/*
+  Source: https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/atom-one-light.min.css
+*/
+.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: .5em;
+  color: #383a42;
+  background: #fafafa
+}
+
+.hljs-comment,
+.hljs-quote {
+  color: #a0a1a7;
+  font-style: italic
+}
+
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula {
+  color: #a626a4
+}
+
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-deletion,
+.hljs-subst {
+  color: #e45649
+}
+
+.hljs-literal {
+  color: #0184bb
+}
+
+.hljs-string,
+.hljs-regexp,
+.hljs-addition,
+.hljs-attribute,
+.hljs-meta-string {
+  color: #50a14f
+}
+
+.hljs-built_in,
+.hljs-class .hljs-title {
+  color: #c18401
+}
+
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #986801
+}
+
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #4078f2
+}
+
+.hljs-emphasis {
+  font-style: italic
+}
+
+.hljs-strong {
+  font-weight: bold
+}
+
+.hljs-link {
+  text-decoration: underline
+}

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -10,7 +10,6 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;900&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Source+Serif+Pro:wght@400;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/atom-one-light.min.css" rel="stylesheet">
   <script defer data-domain="redwoodjs.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>

--- a/web/src/index.scss
+++ b/web/src/index.scss
@@ -2,6 +2,8 @@
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
 
+@import "./atom-one-light.css";
+
 $color_bg: #FDF8F5;
 $color_accent: #BF4722;
 $color_accent2: #F3C7BA;


### PR DESCRIPTION
A little fix to speed up rendering of the page by merging one blocking CSS into main CSS file (793 bytes plain text).