### PR TITLE
Self-host plausible script

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -25,6 +25,7 @@
     "i18n": "^0.14.1",
     "i18next": "^21.6.11",
     "i18next-browser-languagedetector": "^6.1.3",
+    "plausible-tracker": "^0.3.5",
     "prop-types": "15.8.1",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -2,6 +2,12 @@ import { AuthProvider } from '@redwoodjs/auth'
 import { FatalErrorBoundary, RedwoodProvider } from '@redwoodjs/web'
 import { RedwoodApolloProvider } from '@redwoodjs/web/apollo'
 
+import(/* webpackChunkName: "plausible" */ 'plausible-tracker').then(
+  ({ default: Plausible }) => {
+    Plausible({ domain: 'redwoodjs.com' })
+  }
+)
+
 import FatalErrorPage from 'src/pages/FatalErrorPage'
 import Routes from 'src/Routes'
 

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -11,7 +11,6 @@
   <link href="https://fonts.googleapis.com/css2?family=Source+Serif+Pro:wght@400;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/atom-one-light.min.css" rel="stylesheet">
-  <script defer data-domain="redwoodjs.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 <div id="redwood-app" class="flex flex-col text-stone-900" style="min-height: 100vh">

--- a/yarn.lock
+++ b/yarn.lock
@@ -18795,6 +18795,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"plausible-tracker@npm:^0.3.5":
+  version: 0.3.5
+  resolution: "plausible-tracker@npm:0.3.5"
+  checksum: 338ec5da3e77bcbf87dd2452e3ca27a79219d749545797d826e2ec17d92417ba928501f45b60f4799736704df714b38947dfc1376c02efb08d3364c494acea40
+  languageName: node
+  linkType: hard
+
 "pluralize@npm:8.0.0":
   version: 8.0.0
   resolution: "pluralize@npm:8.0.0"
@@ -24098,6 +24105,7 @@ __metadata:
     i18n: ^0.14.1
     i18next: ^21.6.11
     i18next-browser-languagedetector: ^6.1.3
+    plausible-tracker: ^0.3.5
     postcss: ^8.4.6
     postcss-loader: ^6.2.1
     prettier-plugin-tailwindcss: ^0.1.8


### PR DESCRIPTION
In the spirit of performance, self-hosting plausible script should help a little bit.

Because of nature of the feature, there no way to test it locally or in any other domain than production (`data-domain="redwoodjs.com"`), so would be nice to check if it works 100% the same after production deploy.