### PR TITLE
Fix aspect ratio of community logos on the home page

### DIFF
--- a/web/src/components/CommunitySection/CommunitySection.tsx
+++ b/web/src/components/CommunitySection/CommunitySection.tsx
@@ -32,7 +32,7 @@ const CommunitySection = () => {
           <li key={item.name} className="">
             <a href={item.link}>
               <img
-                className="h-10 w-10 md:h-16 md:w-16"
+                className="object-contain h-10 w-10 md:h-16 md:w-16"
                 src={item.logo}
                 alt={item.name}
               />


### PR DESCRIPTION
Problem: community logos on the home page are stretched out. This PR fixes their aspect ratio.

![](https://i.ibb.co/M2v9BRk/community-logos.png)