### PR TITLE
Footer accessibility fixes

### DIFF
--- a/web/src/components/FinalCTASection/FinalCTASection.stories.tsx
+++ b/web/src/components/FinalCTASection/FinalCTASection.stories.tsx
@@ -1,4 +1,4 @@
-import FinalCtaSection from './FinalCtaSection'
+import FinalCtaSection from './FinalCTASection'
 
 export const generated = () => {
   return <FinalCtaSection />

--- a/web/src/components/Footer/Footer.tsx
+++ b/web/src/components/Footer/Footer.tsx
@@ -65,7 +65,7 @@ const navigation = {
     {
       name: 'Newsletter',
       href: 'http://newsletter.redwoodjs.com',
-    },    
+    },
   ],
   icons: [
     {
@@ -249,11 +249,10 @@ const Footer = () => {
                   </ul>
                 </div>
                 <div className="mt-12 md:mt-0">
-                  <ul className="mt-4 space-y-4">
-                    <div className="flex flex-col space-y-6 md:order-2">
-                      {navigation.icons.map((item) => (
+                  <ul className="mt-4 flex flex-col space-y-6">
+                    {navigation.icons.map((item) => (
+                      <li key={item.name}>
                         <a
-                          key={item.name}
                           href={item.href}
                           className="flex items-center text-neutral-400 hover:text-neutral-300"
                         >
@@ -264,8 +263,8 @@ const Footer = () => {
                           />
                           <span>{item.name}</span>
                         </a>
-                      ))}
-                    </div>
+                      </li>
+                    ))}
                   </ul>
                 </div>
               </div>


### PR DESCRIPTION
### Summary
This MR intends to fix an accessibility issue in the footer. We are violating https://dequeuniversity.com/rules/axe/4.4/list, where a `<ul>` must only _directly_ contain a `<li>` element.

Currently, the social elements directly contains a `div`, which violates this rule.

This also fixes an import typo, which breaks storybook when first launched.

### Related Issue
https://github.com/redwoodjs/sprout/issues/45